### PR TITLE
Changed back to default sqlite3 db

### DIFF
--- a/backend_django_api/backend_django_api/settings.py
+++ b/backend_django_api/backend_django_api/settings.py
@@ -76,23 +76,10 @@ WSGI_APPLICATION = 'backend_django_api.wsgi.application'
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 
 # Default Database
-# DATABASES = {
-#     'default': {
-#         'ENGINE': 'django.db.backends.sqlite3',
-#         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-#     }
-# }
-
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        # 'NAME': 'databaseNO',
-        # 'USER': 'wano',
-        # 'PASSWORD': '%Co22o',
-        # 'HOST': '127.0.0.1',
-        'OPTIONS': {
-            'read_default_file': os.path.join(BASE_DIR, 'my.cnf'),
-        },
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
 


### PR DESCRIPTION
Changed back to SQLite3 because there were issues with MySQL Python/Connector in Windows not using the same Python 3.4 version as Linux. This caused issues with other devs who were using Ubuntu distros with mysqlclient that worked with Python 3.6.

Decided SQLite3 is good for testing purposes for now and will convert to PostgreSQL down the track. Not using any specific postgres model fields at this stage so everything in sqlite3 will do.